### PR TITLE
Minor BugFix on branch next

### DIFF
--- a/src/Problem.cc
+++ b/src/Problem.cc
@@ -1386,7 +1386,7 @@ Problem::calc_localpos_and_hash(const Point& pos, const particleinfo& info, floa
 		if (gdata->debug.validate_init_positions)
 			throw std::out_of_range(errmsg.str());
 		else
-			cerr << errmsg << endl;
+			cerr << errmsg.str() << endl;
 	}
 
 	int3 gridPos = calc_grid_pos(pos);

--- a/src/geometries/Disk.cc
+++ b/src/geometries/Disk.cc
@@ -137,7 +137,7 @@ Disk::FillBorder(PointVect& points, const double dx)
 int
 Disk::Fill(PointVect& points, const double dx, const bool fill)
 {
-	return FillDisk(points, m_ep, m_center, m_r, 0.0, dx, 0.0, fill);
+	return FillDisk(points, m_ep, m_center, 0.0, m_r, 0.0, dx, fill);
 }
 
 


### PR DESCRIPTION
``` Disk::Fill ``` was using wrong parameters order when calling ```FillDisk``` function
https://github.com/GPUSPH/gpusph/commit/7afe3843721fe5677925664742e6e7502d853864#diff-be84d537818798e143585ca42e790d5eL140

```errmsg``` needs to be converted to string throught ```errmsg.str()```
https://github.com/GPUSPH/gpusph/commit/d9513fce710ce8a337d6af33a57b76c1ac7509b5#diff-b3c6c6560a291480ee13cf887a84f919L1389


 