### PR TITLE
Fix geometry filling, params validation, deleteGeometry() behaviour & refactoring

### DIFF
--- a/src/XProblem.cc
+++ b/src/XProblem.cc
@@ -1259,9 +1259,6 @@ int XProblem::fill_parts(bool fill)
 		PointVect* parts_vector = NULL;
 		double dx = 0.0;
 
-		// ignore deleted geometries
-		if (!m_geometries[g]->enabled) continue;
-
 		// set dx and recipient vector according to geometry type
 		switch (m_geometries[g]->type) {
 			case GT_FLUID:
@@ -1320,6 +1317,9 @@ int XProblem::fill_parts(bool fill)
 			else
 				m_geometries[g]->ptr->Intersect(m_boundaryParts, unfill_dx);
 		}
+
+		// ignore deleted geometries
+		if (!m_geometries[g]->enabled) continue;
 
 		// after making some space, fill
 		if (fill) {

--- a/src/XProblem.h
+++ b/src/XProblem.h
@@ -243,7 +243,9 @@ class XProblem: public Problem {
 		// request to invert normals while loading - only for HDF5 files
 		void flipNormals(const GeometryID gid, bool flip = true);
 
-		// method for deleting a geometry (actually disabling)
+		/*! Method for deleting a geometry (actually disabling).
+		 *	NOTE: the geometry still use its IntersectionType to intersect preceding geometries.
+		 */
 		void deleteGeometry(const GeometryID gid);
 
 		// methods to enable/disable handling of dynamics/collisions for a specific geometry

--- a/src/geometries/Object.cc
+++ b/src/geometries/Object.cc
@@ -251,13 +251,7 @@ int
 Object::FillDisk(PointVect& points, const EulerParameters& ep, const Point& center,
 		const double r, const double z, const double dx, const bool fill) const
 {
-	const int nr = (int) ceil(r/dx);
-	const double dr = r/nr;
-	int nparts = 0;
-	for (int i = 0; i <= nr; i++)
-		nparts += FillDiskBorder(points, ep, center, i*dr, z, dx, 2.0*M_PI*rand()/RAND_MAX, fill);
-
-	return nparts;
+	return FillDisk(points, ep, center, 0, r, z, dx, fill);
 }
 
 
@@ -280,8 +274,11 @@ int
 Object::FillDisk(PointVect& points, const EulerParameters& ep, const Point& center, const double rmin,
 		const double rmax, const double z, const double dx, const bool fill) const
 {
+	if (rmax < 0) throw std::invalid_argument("FillDisk with maximum radius lower than 0");
+	if (rmin < 0) throw std::invalid_argument("FillDisk with minimum radius lower than 0");
+	if (rmax < rmin) throw std::invalid_argument("FillDisk with maximum radius lower than minimum radius");
 	const int nr = (int) ceil((rmax - rmin)/dx);
-	const double dr = (rmax - rmin)/nr;
+	const double dr = (nr==0)? 0 : (rmax - rmin)/nr;
 	int nparts = 0;
 	for (int i = 0; i <= nr; i++)
 		nparts += FillDiskBorder(points, ep, center, rmin + i*dr, z, dx, 2.0*M_PI*rand()/RAND_MAX, fill);

--- a/src/geometries/Sphere.cc
+++ b/src/geometries/Sphere.cc
@@ -93,13 +93,21 @@ void Sphere::shift(const double3 &offset)
 void
 Sphere::FillBorder(PointVect& points, const double dx)
 {
-	const double angle = dx/m_r;
+	FillBorder(points, dx, m_r);
+}
+
+int
+Sphere::FillBorder(PointVect& points, const double dx, const double r, const bool fill)
+{
+	int nparts = 0;
+	const double angle = dx/r;
 	const int nc = (int) ceil(M_PI/angle); //number of layers
 	const double dtheta = M_PI/nc;
 
 	for (int i = 0; i <= nc; ++i) {
-		FillDiskBorder(points, m_ep, m_center, m_r*sin(i*dtheta), m_r*cos(i*dtheta), dx, 2.0*M_PI*rand()/RAND_MAX);
+		nparts += FillDiskBorder(points, m_ep, m_center, r*sin(i*dtheta), r*cos(i*dtheta), dx, 2.0*M_PI*rand() / RAND_MAX);
 	}
+	return nparts;
 }
 
 
@@ -131,12 +139,11 @@ int
 Sphere::Fill(PointVect& points, const double dx, const bool fill)
 {
 	int nparts = 0;
-	const double angle = dx/m_r;
-	const int nc = (int) ceil(M_PI/angle); //number of layers
-	const double dtheta = M_PI/nc;
+	int nc = round(m_r / dx);
+	double distance = m_r / (nc);
 
 	for (int i = 0; i <= nc; ++i) {
-		nparts += FillDisk(points, m_ep, m_center, m_r*sin(i*dtheta), m_r*cos(i*dtheta), dx, fill);
+		nparts += FillBorder(points, dx, i*distance);
 	}
 
 	return nparts;

--- a/src/geometries/Sphere.cc
+++ b/src/geometries/Sphere.cc
@@ -97,7 +97,7 @@ Sphere::FillBorder(PointVect& points, const double dx)
 	const int nc = (int) ceil(M_PI/angle); //number of layers
 	const double dtheta = M_PI/nc;
 
-	for (int i = - nc; i <= nc; ++i) {
+	for (int i = 0; i <= nc; ++i) {
 		FillDiskBorder(points, m_ep, m_center, m_r*sin(i*dtheta), m_r*cos(i*dtheta), dx, 2.0*M_PI*rand()/RAND_MAX);
 	}
 }
@@ -119,7 +119,7 @@ Sphere::FillIn(PointVect& points, const double dx, const int _layers)
 		const int nc = (int) ceil(M_PI/angle);
 		const double dtheta = M_PI/nc;
 
-		for (int i = - nc; i <= nc; ++i) {
+		for (int i = 0; i <= nc; ++i) {
 			FillDiskBorder(points, m_ep, m_center, r*sin(i*dtheta), r*cos(i*dtheta), dx, 2.0*M_PI*rand()/RAND_MAX);
 		}
 	}
@@ -135,7 +135,7 @@ Sphere::Fill(PointVect& points, const double dx, const bool fill)
 	const int nc = (int) ceil(M_PI/angle); //number of layers
 	const double dtheta = M_PI/nc;
 
-	for (int i = - nc; i <= nc; ++i) {
+	for (int i = 0; i <= nc; ++i) {
 		nparts += FillDisk(points, m_ep, m_center, m_r*sin(i*dtheta), m_r*cos(i*dtheta), dx, fill);
 	}
 

--- a/src/geometries/Sphere.h
+++ b/src/geometries/Sphere.h
@@ -34,7 +34,7 @@
 class Sphere: public Object {
 	private:
 		double	m_r;
-
+		int FillBorder(PointVect&, const double, const double, const bool fill = true);
 	public:
 		Sphere(void);
 		Sphere(const Point &, const double);


### PR DESCRIPTION
- Using `FillBorder(...)` intead of `FillDisk(...)` in `Sphere::Fill(...)` to obtain a better particle distributions and to avoid exceeding the maximum number of neighbors.
- Spawn one particle if disk radius is 0 on `Object::FillDisk(...) const`
- Validation of min and max radius values in `Object::FillDisk(...) const`
- Deleted geometry using `XProblem::deleteGeometry(...)` now still use its IntersectionType to intersect preceding geometries but will not be filled/displayed.