### PR TITLE
Aarch64 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -758,14 +758,19 @@ LIB_PATH_SFX =
 # override: TARGET_ARCH - set the target architecture
 # override:               defaults to -m64 for 64-bit machines
 # override:                           -m32 for 32-bit machines
-ifeq ($(findstring 64,$(arch)), 64)
+ifeq ($(arch), x86_64)
  TARGET_ARCH ?= -m64
- # on Linux, toolkit libraries are under /lib64 for 64-bit
+else ifeq ($(findstring 86,$(arch)), 86) # matches i386 and i686
+ TARGET_ARCH ?= -m32
+else # other architectures such as aarch64 and ppc64
+ TARGET_ARCH ?=
+endif
+
+# on Linux, toolkit libraries are under /lib64 for 64-bit
+ifeq ($(findstring 64,$(arch)), 64)
  ifeq ($(platform), Linux)
   LIB_PATH_SFX = 64
  endif
-else # i386 or i686
- TARGET_ARCH ?= -m32
 endif
 
 # override: INCPATH - paths for include files

--- a/src/cuda/forces.cu
+++ b/src/cuda/forces.cu
@@ -414,9 +414,9 @@ setconstants(const SimParams *simparams, const PhysParams *physparams,
 
 	// Neibs cell to offset table
 	char3 cell_to_offset[27];
-	for(char z=-1; z<=1; z++) {
-		for(char y=-1; y<=1; y++) {
-			for(char x=-1; x<=1; x++) {
+	for(signed char z=-1; z<=1; z++) {
+		for(signed char y=-1; y<=1; y++) {
+			for(signed char x=-1; x<=1; x++) {
 				int i = (x + 1) + (y + 1)*3 + (z + 1)*9;
 				cell_to_offset[i] =  make_char3(x, y, z);
 			}


### PR DESCRIPTION
A pair of fixes for running on aarch64. One resolves a Makefile issue preventing compilation and the other fixes an error caused by different default char signing between x86 and aarch64.